### PR TITLE
Updated RevolutPay SDK version to 2.10

### DIFF
--- a/demo/app/build.gradle
+++ b/demo/app/build.gradle
@@ -44,5 +44,5 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.9.1'
 
     implementation 'com.revolut:revolutpayments:1.0.0'
-    implementation 'com.revolut:revolutpay:2.9'
+    implementation 'com.revolut:revolutpay:2.10'
 }


### PR DESCRIPTION
The new version of the RevolutPay SDK is available, so I have updated 2.9 -> 2.10.